### PR TITLE
Feat/ch 110 redis

### DIFF
--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -7,10 +7,10 @@ spring:
     import: optional:file:.env[.properties]
   data:
     redis:
-      host: redis
+      host: localhost
       port: 6379
-      password:
-      database: 0
+      username: default
+      password: systempass
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration

--- a/benefit-service/build.gradle
+++ b/benefit-service/build.gradle
@@ -52,6 +52,11 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'io.github.openfeign:feign-micrometer'
 
+	// Redisson
+	implementation 'org.redisson:redisson-spring-boot-starter:3.17.6'
+	// jackson-datatype-jsr310 모듈 등록
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
 	// Jackson Databind 의존성 (JSON 직렬화 및 역직렬화)
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'org.springframework.kafka:spring-kafka'

--- a/benefit-service/src/main/java/com/waitless/benefit/coupon/application/dto/CouponHistoryCacheDto.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/coupon/application/dto/CouponHistoryCacheDto.java
@@ -1,0 +1,9 @@
+package com.waitless.benefit.coupon.application.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CouponHistoryCacheDto(
+	UUID id, String title, Long userId, UUID couponId, LocalDateTime expiredAt
+) {
+}

--- a/benefit-service/src/main/java/com/waitless/benefit/coupon/application/exception/CouponErrorCode.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/coupon/application/exception/CouponErrorCode.java
@@ -11,7 +11,7 @@ public enum CouponErrorCode implements ErrorCode {
 
 	COUPON_NOT_FOUND("COUPON_001", "해당 쿠폰을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 	COUPON_ISSUED_IMPOSSIBLE("COUPON_002", "해당 쿠폰을 발급할 수 있는 날짜가 지났습니다.", HttpStatus.BAD_REQUEST),
-	COUPON_AMOUNT_EXHAUSTED("COUPON_003", "해당 쿠폰을 발급할 수 있는 날짜가 지났습니다.", HttpStatus.INSUFFICIENT_STORAGE),
+	COUPON_AMOUNT_EXHAUSTED("COUPON_003", "해당 쿠폰 발급 가능 수량이 모두 소진되었습니다.", HttpStatus.INSUFFICIENT_STORAGE),
 	COUPONHISTORY_NOT_FOUND("COUPON_004", "해당 쿠폰발급내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 	COUPONHISTORY_UNAUTHORIZED("COUPON_005", "해당 쿠폰발급내역에 대한 권한이 없습니다.", HttpStatus.UNAUTHORIZED),
 	ISSUED_COUPON_EXPIRED("COUPON_006", "해당 쿠폰은 만료되었습니다.", HttpStatus.BAD_REQUEST),

--- a/benefit-service/src/main/java/com/waitless/benefit/coupon/application/exception/CouponErrorCode.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/coupon/application/exception/CouponErrorCode.java
@@ -15,7 +15,8 @@ public enum CouponErrorCode implements ErrorCode {
 	COUPONHISTORY_NOT_FOUND("COUPON_004", "해당 쿠폰발급내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 	COUPONHISTORY_UNAUTHORIZED("COUPON_005", "해당 쿠폰발급내역에 대한 권한이 없습니다.", HttpStatus.UNAUTHORIZED),
 	ISSUED_COUPON_EXPIRED("COUPON_006", "해당 쿠폰은 만료되었습니다.", HttpStatus.BAD_REQUEST),
-	COUPON_ALREADY_USED("COUPON_007", "해당 쿠폰은 이미 사용되었습니다.", HttpStatus.BAD_REQUEST);
+	COUPON_ALREADY_USED("COUPON_007", "해당 쿠폰은 이미 사용되었습니다.", HttpStatus.BAD_REQUEST),
+	COUPONHISTORY_TRY_AGAIN("COUPON_008", "다른 사용자가 쿠폰을 발급중입니다. 잠시 후 다시 한번 시도해주세요.", HttpStatus.BAD_REQUEST);
 
 	private final String code;
 	private final String message;

--- a/benefit-service/src/main/java/com/waitless/benefit/coupon/application/mapper/CouponHistoryServiceMapper.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/coupon/application/mapper/CouponHistoryServiceMapper.java
@@ -3,6 +3,7 @@ package com.waitless.benefit.coupon.application.mapper;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
+import com.waitless.benefit.coupon.application.dto.CouponHistoryCacheDto;
 import com.waitless.benefit.coupon.application.dto.CouponHistoryResponseDto;
 import com.waitless.benefit.coupon.domain.entity.CouponHistory;
 
@@ -11,4 +12,6 @@ public interface CouponHistoryServiceMapper {
 
 	@Mapping(target = "id", source = "id")
 	CouponHistoryResponseDto toCouponHistoryResponseDto(CouponHistory couponHistory);
+
+	CouponHistory toCouponHistory(CouponHistoryCacheDto couponHistoryCacheDto);
 }

--- a/benefit-service/src/main/java/com/waitless/benefit/coupon/application/service/CouponHistoryService.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/coupon/application/service/CouponHistoryService.java
@@ -9,13 +9,13 @@ import com.waitless.benefit.coupon.application.dto.CouponHistoryResponseDto;
 import com.waitless.benefit.coupon.application.dto.ReadCouponHistoriesDto;
 
 public interface CouponHistoryService {
-	CouponHistoryResponseDto issuedCoupon(UUID couponId, String userId);
+	CouponHistoryResponseDto issuedCoupon(UUID couponId, Long userId);
 
 	CouponHistoryResponseDto findCouponHistory(UUID id);
 
 	Page<CouponHistoryResponseDto> findAndSearchCouponHistories(ReadCouponHistoriesDto readCouponHistoriesDto, Pageable pageable);
 
-	void removeCouponHistory(UUID id, String userId);
+	void removeCouponHistory(UUID id, Long userId);
 
-	void userIssuedCoupon(UUID id, String userId);
+	void userIssuedCoupon(UUID id, Long userId);
 }

--- a/benefit-service/src/main/java/com/waitless/benefit/coupon/application/service/CouponHistoryServiceImpl.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/coupon/application/service/CouponHistoryServiceImpl.java
@@ -1,13 +1,17 @@
 package com.waitless.benefit.coupon.application.service;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
-import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,7 +21,6 @@ import com.waitless.benefit.coupon.application.dto.ReadCouponHistoriesDto;
 import com.waitless.benefit.coupon.application.exception.CouponBusinessException;
 import com.waitless.benefit.coupon.application.exception.CouponErrorCode;
 import com.waitless.benefit.coupon.application.mapper.CouponHistoryServiceMapper;
-import com.waitless.benefit.coupon.domain.entity.Coupon;
 import com.waitless.benefit.coupon.domain.entity.CouponHistory;
 import com.waitless.benefit.coupon.domain.repository.CouponHistoryRepository;
 import com.waitless.benefit.coupon.infrastructure.repository.CustomCouponHistoryRepository;
@@ -32,33 +35,57 @@ public class CouponHistoryServiceImpl implements CouponHistoryService{
 	private final CustomCouponHistoryRepository customCouponHistoryRepository;
 	private final CouponHistoryServiceMapper couponHistoryServiceMapper;
 	private final CouponService couponService;
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final RedissonClient redissonClient;
 
 	// 쿠폰 받기
 	@Override
 	@Transactional
-	public CouponHistoryResponseDto issuedCoupon(UUID couponId, String userId) { // redisson 분산 락...
-		CouponResponseDto couponInfo = couponService.findCoupon(couponId);
-		// 쿠폰 수량 확인 후
-		if (couponInfo.amount() <= 0) {
-			throw CouponBusinessException.from(CouponErrorCode.COUPON_AMOUNT_EXHAUSTED);
-		}
-		LocalDateTime today = LocalDateTime.now();
-		// 쿠폰 발급 가능일자가 지나면 예외처리
-		if (!today.isBefore(couponInfo.issuanceDate())) {
+	public CouponHistoryResponseDto issuedCoupon(UUID couponId, Long userId) {
+		String lockKey = "LOCK:CH:" + couponId;
+		RLock lock = redissonClient.getLock(lockKey);
+		boolean isLocked = false;
+		try {
+			isLocked = lock.tryLock(5, 3, TimeUnit.SECONDS);
+			if (!isLocked) {
+				throw CouponBusinessException.from(CouponErrorCode.COUPONHISTORY_TRY_AGAIN);
+			}
+
+			// 쿠폰 발급 시작
+			CouponResponseDto couponInfo = couponService.findCoupon(couponId);
+			// 쿠폰 수량 확인 후
+			if (couponInfo.amount() <= 0) {
+				throw CouponBusinessException.from(CouponErrorCode.COUPON_AMOUNT_EXHAUSTED);
+			}
+			LocalDateTime today = LocalDateTime.now();
+			// 쿠폰 발급 가능일자가 지나면 예외처리
+			if (!today.isBefore(couponInfo.issuanceDate())) {
+				throw CouponBusinessException.from(CouponErrorCode.COUPON_ISSUED_IMPOSSIBLE);
+			}
+			// 쿠폰 사용 가능 일자
+			LocalDateTime expiredDate = today.plusDays(couponInfo.validPeriod());
+			CouponHistory couponHistory = CouponHistory.builder()
+				.title(couponInfo.title())
+				.couponId(couponId)
+				.userId(userId)
+				.isValid(true)
+				.expiredAt(expiredDate)
+				.build();
+			// 쿠폰 발급가능수량 -1 차감
+			couponService.decreaseCouponAmount(couponId);
+			CouponHistory saved = couponHistoryRepository.save(couponHistory);
+			// Redis 캐싱
+			redisTemplate.opsForValue().set("CH:"+ saved.getId(), couponHistory, Duration.ofHours(1));
+
+			return couponHistoryServiceMapper.toCouponHistoryResponseDto(saved);
+		} catch(InterruptedException e) {
+			Thread.currentThread().interrupt();
 			throw CouponBusinessException.from(CouponErrorCode.COUPON_ISSUED_IMPOSSIBLE);
+		} finally {
+			if (isLocked && lock.isHeldByCurrentThread()) {
+				lock.unlock();
+			}
 		}
-		// 쿠폰 사용 가능 일자
-		LocalDateTime expiredDate = today.plusDays(couponInfo.validPeriod());
-		CouponHistory couponHistory = CouponHistory.builder()
-			.title(couponInfo.title())
-			.couponId(couponId)
-			.userId(Long.parseLong(userId))
-			.isValid(true)
-			.expiredAt(expiredDate)
-			.build();
-		// 쿠폰 발급가능수량 -1 차감
-		couponService.decreaseCouponAmount(couponId);
-		return couponHistoryServiceMapper.toCouponHistoryResponseDto(couponHistoryRepository.save(couponHistory));
 	}
 
 	// 쿠폰발급내역 단건 조회
@@ -88,9 +115,9 @@ public class CouponHistoryServiceImpl implements CouponHistoryService{
 	// 쿠폰발급내역 삭제
 	@Override
 	@Transactional
-	public void removeCouponHistory(UUID id, String userId) {
+	public void removeCouponHistory(UUID id, Long userId) {
 		CouponHistory couponHistory = findCouponHistoryById(id);
-		if (!couponHistory.getUserId().equals(Long.parseLong(userId))) {
+		if (!couponHistory.getUserId().equals(userId)) {
 			throw CouponBusinessException.from(CouponErrorCode.COUPONHISTORY_UNAUTHORIZED);
 		}
 		couponHistory.delete();
@@ -99,10 +126,9 @@ public class CouponHistoryServiceImpl implements CouponHistoryService{
 	// 발급된 쿠폰 사용
 	@Override
 	@Transactional
-	public void userIssuedCoupon(UUID id, String userId) {
+	public void userIssuedCoupon(UUID id, Long userId) {
 		CouponHistory couponHistory = findCouponHistoryById(id);
-		long loginuser = Long.parseLong(userId);
-		if (!couponHistory.getUserId().equals(loginuser)) {
+		if (!couponHistory.getUserId().equals(userId)) {
 			throw CouponBusinessException.from(CouponErrorCode.COUPONHISTORY_UNAUTHORIZED);
 		}
 		if (couponHistory.getExpiredAt().isBefore(LocalDateTime.now())) {
@@ -115,8 +141,15 @@ public class CouponHistoryServiceImpl implements CouponHistoryService{
 	}
 
 	private CouponHistory findCouponHistoryById(UUID id) {
+		String key = "CH:" + id;
+		CouponHistory cached = (CouponHistory) redisTemplate.opsForValue().get(key);
+		if (cached != null) {
+			return cached;
+		}
 		CouponHistory couponHistory = couponHistoryRepository.findById(id)
 			.orElseThrow(()-> CouponBusinessException.from(CouponErrorCode.COUPONHISTORY_NOT_FOUND));
+		redisTemplate.opsForValue().set(key, couponHistory, Duration.ofHours(1));
+
 		return couponHistory;
 	}
 

--- a/benefit-service/src/main/java/com/waitless/benefit/coupon/application/service/CouponService.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/coupon/application/service/CouponService.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import com.waitless.benefit.coupon.application.dto.CouponResponseDto;
 import com.waitless.benefit.coupon.application.dto.CreateCouponDto;
 import com.waitless.benefit.coupon.application.dto.ReadCouponsDto;
+import com.waitless.benefit.coupon.domain.entity.Coupon;
 
 public interface CouponService {
 	CouponResponseDto generateCoupon(CreateCouponDto createCouponDto);
@@ -21,5 +22,5 @@ public interface CouponService {
 
 	void removeCoupon(UUID id);
 
-	void decreaseCouponAmount(UUID id);
+	Coupon decreaseCouponAmount(UUID id);
 }

--- a/benefit-service/src/main/java/com/waitless/benefit/coupon/application/service/CouponServiceImpl.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/coupon/application/service/CouponServiceImpl.java
@@ -81,9 +81,14 @@ public class CouponServiceImpl implements CouponService {
 	// 쿠폰 수량 감소
 	@Override
 	@Transactional
-	public void decreaseCouponAmount(UUID id) {
-		Coupon coupon = findCouponById(id);
+	public Coupon decreaseCouponAmount(UUID id) {
+		Coupon coupon = couponRepository.findByIdForUpdate(id)
+			.orElseThrow(()-> CouponBusinessException.from(CouponErrorCode.COUPON_NOT_FOUND));
+		if (coupon.getAmount() <= 0) {
+			throw CouponBusinessException.from(CouponErrorCode.COUPON_AMOUNT_EXHAUSTED);
+		}
 		coupon.decrease();
+		return coupon;
 	}
 
 	private Coupon findCouponById(UUID id) {

--- a/benefit-service/src/main/java/com/waitless/benefit/coupon/domain/entity/CouponHistory.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/coupon/domain/entity/CouponHistory.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import org.hibernate.annotations.Where;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.waitless.common.domain.BaseTimeEntity;
 
 import jakarta.persistence.Column;

--- a/benefit-service/src/main/java/com/waitless/benefit/coupon/domain/repository/CouponRepository.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/coupon/domain/repository/CouponRepository.java
@@ -14,4 +14,5 @@ public interface CouponRepository {
 
 	Optional<Coupon> findById(UUID id);
 
+	Optional<Coupon> findByIdForUpdate(UUID id);
 }

--- a/benefit-service/src/main/java/com/waitless/benefit/coupon/infrastructure/config/RedisConfig.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/coupon/infrastructure/config/RedisConfig.java
@@ -4,7 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -18,16 +18,16 @@ public class RedisConfig {
 		RedisTemplate<String, Object> template = new RedisTemplate<>();
 		template.setConnectionFactory(connectionFactory);
 
-		ObjectMapper mapper = new ObjectMapper();
-		mapper.registerModule(new JavaTimeModule());
-		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+		ObjectMapper mapper = new ObjectMapper()
+			.registerModule(new JavaTimeModule())
+			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
-		GenericJackson2JsonRedisSerializer serializer =
-			new GenericJackson2JsonRedisSerializer(mapper);
+		Jackson2JsonRedisSerializer<Object> serializer =
+			new Jackson2JsonRedisSerializer<>(mapper, Object.class);
 
-		template.setDefaultSerializer(serializer);
 		template.setKeySerializer(new StringRedisSerializer());
 		template.setValueSerializer(serializer);
+		template.setDefaultSerializer(serializer);
 
 		return template;
 	}

--- a/benefit-service/src/main/java/com/waitless/benefit/coupon/infrastructure/config/RedisConfig.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/coupon/infrastructure/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.waitless.benefit.coupon.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+public class RedisConfig {
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+
+		ObjectMapper mapper = new ObjectMapper();
+		mapper.registerModule(new JavaTimeModule());
+		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+		GenericJackson2JsonRedisSerializer serializer =
+			new GenericJackson2JsonRedisSerializer(mapper);
+
+		template.setDefaultSerializer(serializer);
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(serializer);
+
+		return template;
+	}
+}

--- a/benefit-service/src/main/java/com/waitless/benefit/coupon/infrastructure/config/RedissonConfig.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/coupon/infrastructure/config/RedissonConfig.java
@@ -1,0 +1,19 @@
+package com.waitless.benefit.coupon.infrastructure.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+	@Bean
+	public RedissonClient redissonClient() {
+		Config config = new Config();
+		config.useSingleServer()
+			.setAddress("redis://localhost:6379")
+			.setPassword("systempass");
+		return Redisson.create(config);
+	}
+}

--- a/benefit-service/src/main/java/com/waitless/benefit/coupon/infrastructure/repository/CouponRepositoryImpl.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/coupon/infrastructure/repository/CouponRepositoryImpl.java
@@ -45,6 +45,11 @@ public class CouponRepositoryImpl implements CouponRepository, CustomCouponRepos
 	}
 
 	@Override
+	public Optional<Coupon> findByIdForUpdate(UUID id) {
+		return jpaCouponRepository.findByIdForUpdate(id);
+	}
+
+	@Override
 	public Page<Coupon> findAndSearchCoupons(String title, Sort.Direction sortDirection, String sortBy, Pageable pageable) {
 		OrderSpecifier<?> orderSpecifier = getOrderSpecifier(sortDirection, sortBy);
 		BooleanBuilder builder = new BooleanBuilder();

--- a/benefit-service/src/main/java/com/waitless/benefit/coupon/infrastructure/repository/JpaCouponRepository.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/coupon/infrastructure/repository/JpaCouponRepository.java
@@ -1,10 +1,19 @@
 package com.waitless.benefit.coupon.infrastructure.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import com.waitless.benefit.coupon.domain.entity.Coupon;
 
+import jakarta.persistence.LockModeType;
+
 public interface JpaCouponRepository extends JpaRepository<Coupon, UUID> {
+
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT c FROM Coupon c WHERE c.id = :id")
+	Optional<Coupon> findByIdForUpdate(UUID id);
 }

--- a/benefit-service/src/main/java/com/waitless/benefit/coupon/infrastructure/service/CouponSchedulerImpl.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/coupon/infrastructure/service/CouponSchedulerImpl.java
@@ -2,7 +2,6 @@ package com.waitless.benefit.coupon.infrastructure.service;
 
 import java.util.List;
 
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/benefit-service/src/main/java/com/waitless/benefit/coupon/presentation/controller/CouponController.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/coupon/presentation/controller/CouponController.java
@@ -87,7 +87,7 @@ public class CouponController {
 	// 쿠폰 받기
 	@PostMapping("/issued/{couponId}")
 	public ResponseEntity<SingleResponse<CouponHistoryResponseDto>> issuedCoupon(
-		@PathVariable UUID couponId, @RequestHeader("X-User-Id") String userId) {
+		@PathVariable UUID couponId, @RequestHeader("X-User-Id") Long userId) {
 		CouponHistoryResponseDto couponHistoryResponseDto = couponHistoryService.issuedCoupon(couponId, userId);
 		return ResponseEntity.ok(SingleResponse.success(couponHistoryResponseDto));
 	}
@@ -117,21 +117,14 @@ public class CouponController {
 
 	// 쿠폰발급내역 삭제
 	@DeleteMapping("/history/{id}")
-	public ResponseEntity<Void> deleteCouponHistory(@PathVariable UUID id, @RequestHeader("X-User-Id") String userId) {
-		couponHistoryService.removeCouponHistory(id, userId);
-		return ResponseEntity.noContent().build();
-	}
-
-	// 쿠폰발급내역 삭제
-	@DeleteMapping("/history/{id}")
-	public ResponseEntity<Void> deleteCouponHistory(@PathVariable UUID id, @RequestHeader("X-User-Id") String userId) {
+	public ResponseEntity<Void> deleteCouponHistory(@PathVariable UUID id, @RequestHeader("X-User-Id") Long userId) {
 		couponHistoryService.removeCouponHistory(id, userId);
 		return ResponseEntity.noContent().build();
 	}
 
 	// 발급된 쿠폰 사용
 	@PostMapping("/use/{id}")
-	public ResponseEntity<String> useIssuedCoupon(@PathVariable UUID id, @RequestHeader("X-User-Id") String userId) {
+	public ResponseEntity<String> useIssuedCoupon(@PathVariable UUID id, @RequestHeader("X-User-Id") Long userId) {
 		couponHistoryService.userIssuedCoupon(id, userId);
 		return ResponseEntity.ok("쿠폰 사용 완료");
 	}

--- a/benefit-service/src/main/resources/application.yml
+++ b/benefit-service/src/main/resources/application.yml
@@ -18,6 +18,12 @@ spring:
   jackson:
     serialization:
       fail-on-empty-beans: false
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      username: default
+      password: systempass
   kafka:
     bootstrap-servers: localhost:9092
     producer:

--- a/benefit-service/src/main/resources/http/coupon-test.http
+++ b/benefit-service/src/main/resources/http/coupon-test.http
@@ -4,7 +4,7 @@ Content-Type: application/json
 
 {
   "title" : "20% 할인 쿠폰",
-  "amount" : 100,
+  "amount" : 10,
   "issuanceDate": "2025-04-30T18:00:00",
   "validPeriod": 14
 }

--- a/benefit-service/src/main/resources/http/coupon-test.http
+++ b/benefit-service/src/main/resources/http/coupon-test.http
@@ -29,10 +29,10 @@ Content-Type: application/json
 DELETE http://localhost:19091/api/coupons/6b52df77-56e4-44f0-a71d-2ffdb2371a60
 
 ### 쿠폰 받기
-POST http://localhost:19091/api/coupons/issued/b5b8f62f-7ec7-437c-b162-33177b73a752
+POST http://localhost:19091/api/coupons/issued/3d2ea000-f54b-4617-b142-199f449640bf
 
 ### 쿠폰발급내역 단건 조회
-GET http://localhost:19091/api/coupons/history/f5760e84-9bf5-4b70-95f2-1c198b75169b
+GET http://localhost:19091/api/coupons/history/80243b89-fda4-4175-b2ef-724074cd39ca
 
 ### 쿠폰발급내역 목록 조회
 GET http://localhost:19091/api/coupons/history?title=2


### PR DESCRIPTION
## 🔍 작업 내용
>어떤 작업을 했는지 요약해주세요.

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 분산 락 > 동시성 이슈로 비관적 락 설정
- 쿠폰발급내역 단건 조회시 Redis 캐싱 데이터 가져오기

## ✅ 체크리스트
> 혹시 빠뜨린 건 없는지! 체크리스트 한 번만 더 확인해볼까요? 👀
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 브랜치를 최신화 했나요?
- [ ] 테스트를 완료 했나요?

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


## 🔗 관련 이슈
> pr에 관련된 issue num 을 작성해 주세요.

Closes #110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced distributed locking to prevent concurrent coupon issuance conflicts.
  - Added Redis caching for faster coupon history retrieval.
  - Enhanced error handling with a new error code for concurrent issuance attempts.
  - Added support for Java 8 date/time types in Redis serialization.

- **Improvements**
  - Updated coupon issuance logic to ensure atomic operations and better concurrency control.
  - Changed user ID handling from String to Long for improved consistency.
  - Modified coupon amount decrease to return the updated coupon information.
  - Improved error messages for exhausted coupon quantities.

- **Configuration**
  - Added and updated Redis and Redisson configuration settings for secure and efficient operation.

- **Bug Fixes**
  - Corrected error messages related to coupon issuance limits.

- **Documentation**
  - Updated test payloads and examples for clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->