### PR TITLE
Feat/reservation 163 menu saga create

### DIFF
--- a/common/src/main/java/com/waitless/common/dto/ReservationCancelEvent.java
+++ b/common/src/main/java/com/waitless/common/dto/ReservationCancelEvent.java
@@ -1,0 +1,4 @@
+package com.waitless.common.dto;
+
+public record ReservationCancelEvent(String slackId, String message) {
+}

--- a/common/src/main/java/com/waitless/common/event/StockDecreasedEvent.java
+++ b/common/src/main/java/com/waitless/common/event/StockDecreasedEvent.java
@@ -2,6 +2,8 @@ package com.waitless.common.event;
 
 import com.waitless.common.dto.StockDto;
 import java.util.List;
+import java.util.UUID;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,6 +13,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class StockDecreasedEvent {
 
+    private UUID reservationId;
     private List<StockDto> stockDtoList;
 
 }

--- a/reservation-service/src/main/java/com/waitless/reservation/application/event/KafkaSlackEventProducer.java
+++ b/reservation-service/src/main/java/com/waitless/reservation/application/event/KafkaSlackEventProducer.java
@@ -1,5 +1,6 @@
 package com.waitless.reservation.application.event;
 
+import com.waitless.common.dto.ReservationCancelEvent;
 import com.waitless.reservation.application.event.dto.ReviewRequestEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -10,9 +11,15 @@ import org.springframework.stereotype.Component;
 public class KafkaSlackEventProducer {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
-    private static final String TOPIC = "review-request";
+    private static final String REVIEW_TOPIC = "review-request";
+    private static final String CANCEL_TOPIC = "cancel-request";
+
 
     public void sendReviewRequest(ReviewRequestEvent event) {
-        kafkaTemplate.send(TOPIC, event);
+        kafkaTemplate.send(REVIEW_TOPIC, event);
+    }
+
+    public void sendCancelRequest(ReservationCancelEvent event) {
+        kafkaTemplate.send(CANCEL_TOPIC, event);
     }
 }

--- a/reservation-service/src/main/java/com/waitless/reservation/application/event/StockDecreaseEventProducer.java
+++ b/reservation-service/src/main/java/com/waitless/reservation/application/event/StockDecreaseEventProducer.java
@@ -7,12 +7,12 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class StockEventProducer {
+public class StockDecreaseEventProducer {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private static final String TOPIC = "restaurant-stock-decrease";
 
-    public void sendStockRequest(StockDecreasedEvent event) {
-        kafkaTemplate.send(TOPIC, event);
+    public void publish(StockDecreasedEvent event) {
+        kafkaTemplate.send(TOPIC,"stock-key",  event);
     }
 }

--- a/reservation-service/src/main/java/com/waitless/reservation/application/event/StockEventHandler.java
+++ b/reservation-service/src/main/java/com/waitless/reservation/application/event/StockEventHandler.java
@@ -13,13 +13,13 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Slf4j
 public class StockEventHandler {
 
-    private final StockEventProducer stockEventProducer;
+    private final StockDecreaseEventProducer stockDecreaseEventProducer;
 
     @Async("messageExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleReservationVisited(StockDecreasedEvent event) {
         try {
-            stockEventProducer.sendStockRequest(event);
+            stockDecreaseEventProducer.publish(event);
         } catch (Exception e) {
             log.error("Error sending stock request", e);
         }

--- a/reservation-service/src/main/java/com/waitless/reservation/application/event/dto/ReservationCancelRequestEvent.java
+++ b/reservation-service/src/main/java/com/waitless/reservation/application/event/dto/ReservationCancelRequestEvent.java
@@ -1,0 +1,4 @@
+package com.waitless.reservation.application.event.dto;
+
+public record ReservationCancelRequestEvent(Long userId, String restaurantName) {
+}

--- a/reservation-service/src/main/java/com/waitless/reservation/application/service/message/MessageService.java
+++ b/reservation-service/src/main/java/com/waitless/reservation/application/service/message/MessageService.java
@@ -2,4 +2,6 @@ package com.waitless.reservation.application.service.message;
 
 public interface MessageService {
     String buildVisitCompleteMessage(String slackId, String restaurantName, Long userId);
+
+    String buildCancelMessage(String restaurantName);
 }

--- a/reservation-service/src/main/java/com/waitless/reservation/application/service/message/SlackMessageService.java
+++ b/reservation-service/src/main/java/com/waitless/reservation/application/service/message/SlackMessageService.java
@@ -10,9 +10,18 @@ public class SlackMessageService implements MessageService {
     private static final String REVIEW_URL_TEMPLATE =
             "https://www.xxx.com/api/reservation?userId=%s";
 
+    private static final String CANCEL_MESSAGE_TEMPLATE =
+            "%s 예약이 취소되었습니다.\n취소하신 적이 없으면 고객센터로 연락주세요.";
+
+
     @Override
     public String buildVisitCompleteMessage(String slackId, String restaurantName, Long userId) {
         String reviewLink = String.format(REVIEW_URL_TEMPLATE, userId);
         return String.format(REVIEW_MESSAGE_TEMPLATE, restaurantName, reviewLink);
+    }
+
+    @Override
+    public String buildCancelMessage(String restaurantName) {
+        return String.format(CANCEL_MESSAGE_TEMPLATE, restaurantName);
     }
 }

--- a/reservation-service/src/main/java/com/waitless/reservation/infrastructure/adaptor/kafka/StockDecreaseKafkaListener.java
+++ b/reservation-service/src/main/java/com/waitless/reservation/infrastructure/adaptor/kafka/StockDecreaseKafkaListener.java
@@ -1,18 +1,23 @@
 package com.waitless.reservation.infrastructure.adaptor.kafka;
 
 import com.waitless.common.event.StockDecreasedEvent;
+import com.waitless.reservation.application.service.command.ReservationCommandService;
+import com.waitless.reservation.application.service.redis.RedisStockService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class StockDecreaseKafkaListener {
-    private static final String TOPIC_NAME = "restaurant-stock-decrease";
-    private static final String GROUP_ID = "restaurant-stock-consumer";
+    private final ReservationCommandService reservationCommandService;
+    private static final String TOPIC_NAME = "restaurant-stock-decrease-failed-events";
+    private static final String GROUP_ID = "restaurant-stock-fail-consumer";
 
     @KafkaListener(topics = TOPIC_NAME, groupId = GROUP_ID)
     public void consume(StockDecreasedEvent event) {
-
+        reservationCommandService.cancelReservation(event.getReservationId());
     }
 }

--- a/reservation-service/src/main/java/com/waitless/reservation/infrastructure/adaptor/kafka/StockDecreaseKafkaListener.java
+++ b/reservation-service/src/main/java/com/waitless/reservation/infrastructure/adaptor/kafka/StockDecreaseKafkaListener.java
@@ -1,0 +1,18 @@
+package com.waitless.reservation.infrastructure.adaptor.kafka;
+
+import com.waitless.common.event.StockDecreasedEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class StockDecreaseKafkaListener {
+    private static final String TOPIC_NAME = "restaurant-stock-decrease";
+    private static final String GROUP_ID = "restaurant-stock-consumer";
+
+    @KafkaListener(topics = TOPIC_NAME, groupId = GROUP_ID)
+    public void consume(StockDecreasedEvent event) {
+
+    }
+}


### PR DESCRIPTION
## 🔍 작업 내용
>메뉴서비스에서 재고 처리 로직 실패 시 보상 트랜잭션으로 재고 원복 후 주문 취소 메시지 발행

## 📝작업 내용
메뉴서비스에서 재고 줄이는 로직 실패 시 카프카 컨슈머로 메시지 받고 레디스에 재고 원복, 레디스 대기순번 큐에서 제거 

## ✅ 체크리스트
> 혹시 빠뜨린 건 없는지! 체크리스트 한 번만 더 확인해볼까요? 👀
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 브랜치를 최신화 했나요?
- [ ] 테스트를 완료 했나요?

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


## 🔗 관련 이슈
> pr에 관련된 issue num 을 작성해 주세요.

Closes #163 