### PR TITLE
feat: 내부호출에도 권한검증 추가, Auditing기능 추가

### DIFF
--- a/benefit-service/src/main/java/com/waitless/benefit/point/application/dto/command/GetMyRankingCommand.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/point/application/dto/command/GetMyRankingCommand.java
@@ -1,5 +1,8 @@
 package com.waitless.benefit.point.application.dto.command;
 
+import com.waitless.common.domain.UserInfoDto;
+
 public record GetMyRankingCommand(
-        Long userId
+        Long userId,
+        UserInfoDto userInfoDto
 ) {}

--- a/benefit-service/src/main/java/com/waitless/benefit/point/application/dto/command/GetPointAmountCommand.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/point/application/dto/command/GetPointAmountCommand.java
@@ -1,5 +1,8 @@
 package com.waitless.benefit.point.application.dto.command;
 
+import com.waitless.common.domain.UserInfoDto;
+
 public record GetPointAmountCommand(
-        Long userId
+        Long userId,
+        UserInfoDto userInfoDto
 ) {}

--- a/benefit-service/src/main/java/com/waitless/benefit/point/application/dto/command/SearchRankingCommand.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/point/application/dto/command/SearchRankingCommand.java
@@ -1,5 +1,8 @@
 package com.waitless.benefit.point.application.dto.command;
 
+import com.waitless.common.domain.UserInfoDto;
+
 public record SearchRankingCommand(
-        int topN
+        int topN,
+        UserInfoDto userInfoDto
 ) {}

--- a/benefit-service/src/main/java/com/waitless/benefit/point/presentation/controller/PointExternalController.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/point/presentation/controller/PointExternalController.java
@@ -8,6 +8,10 @@ import com.waitless.benefit.point.domain.vo.PointSearchCondition;
 import com.waitless.benefit.point.presentation.dto.request.*;
 import com.waitless.benefit.point.presentation.dto.response.*;
 import com.waitless.benefit.point.presentation.mapper.PointControllerMapper;
+import com.waitless.common.aop.RoleCheck;
+import com.waitless.common.domain.Role;
+import com.waitless.common.domain.UserInfo;
+import com.waitless.common.domain.UserInfoDto;
 import com.waitless.common.exception.response.SingleResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -24,9 +28,11 @@ public class PointExternalController {
     private final PointQueryService pointQueryService;
     private final PointControllerMapper pointControllerMapper;
 
+    @RoleCheck(roles = {Role.ADMIN, Role.USER})
     @GetMapping("/{reviewId}")
     public ResponseEntity<SingleResponse<GetPointResponseDto>> getPoint(
-            @PathVariable("reviewId") UUID reviewId
+            @PathVariable("reviewId") UUID reviewId,
+            @UserInfo UserInfoDto userInfoDto
     ) {
         GetPointRequestDto requestDto = new GetPointRequestDto(reviewId);
         PointSearchCondition condition = pointControllerMapper.toCondition(requestDto);
@@ -36,10 +42,12 @@ public class PointExternalController {
         return ResponseEntity.ok(SingleResponse.success(responseDto));
     }
 
+    @RoleCheck(roles = {Role.ADMIN, Role.USER})
     @GetMapping("/list")
     public ResponseEntity<SingleResponse<GetPointListResponseDto>> getPointList(
             @ModelAttribute GetPointListRequestDto requestDto,
-            Pageable pageable
+            Pageable pageable,
+            @UserInfo UserInfoDto userInfoDto
     ) {
         PointSearchCondition condition = pointControllerMapper.toCondition(requestDto);
         GetPointListResponseDto responseDto = GetPointListResponseDto.from(
@@ -48,33 +56,39 @@ public class PointExternalController {
         return ResponseEntity.ok(SingleResponse.success(responseDto));
     }
 
+    @RoleCheck(roles = {Role.ADMIN, Role.USER})
     @GetMapping("/amount")
     public ResponseEntity<SingleResponse<GetPointAmountResponseDto>> getTotalPoint(
-            @ModelAttribute GetPointAmountRequestDto requestDto
+            @ModelAttribute GetPointAmountRequestDto requestDto,
+            @UserInfo UserInfoDto userInfoDto
     ) {
-        GetPointAmountCommand command = pointControllerMapper.toCommand(requestDto);
+        GetPointAmountCommand command = pointControllerMapper.toCommand(requestDto, userInfoDto);
         GetPointAmountResponseDto responseDto = GetPointAmountResponseDto.from(
                 pointQueryService.getTotalAmount(command)
         );
         return ResponseEntity.ok(SingleResponse.success(responseDto));
     }
 
+    @RoleCheck(roles = {Role.ADMIN, Role.USER})
     @GetMapping("/ranking/top")
     public ResponseEntity<SingleResponse<SearchRankingResponseDto>> getTopRanking(
-            @ModelAttribute SearchRankingRequestDto requestDto
+            @ModelAttribute SearchRankingRequestDto requestDto,
+            @UserInfo UserInfoDto userInfoDto
     ) {
-        SearchRankingCommand command = pointControllerMapper.toCommand(requestDto);
+        SearchRankingCommand command = pointControllerMapper.toCommand(requestDto, userInfoDto);
         SearchRankingResponseDto responseDto = SearchRankingResponseDto.from(
                 pointQueryService.getTopRanking(command)
         );
         return ResponseEntity.ok(SingleResponse.success(responseDto));
     }
 
+    @RoleCheck(roles = {Role.ADMIN, Role.USER})
     @GetMapping("/ranking/me")
     public ResponseEntity<SingleResponse<GetMyRankingResponseDto>> getMyRanking(
-            @ModelAttribute GetMyRankingRequestDto requestDto
+            @ModelAttribute GetMyRankingRequestDto requestDto,
+            @UserInfo UserInfoDto userInfoDto
     ) {
-        GetMyRankingCommand command = pointControllerMapper.toCommand(requestDto);
+        GetMyRankingCommand command = pointControllerMapper.toCommand(requestDto, userInfoDto);
         GetMyRankingResponseDto responseDto = GetMyRankingResponseDto.from(
                 pointQueryService.getMyRanking(command)
         );

--- a/benefit-service/src/main/java/com/waitless/benefit/point/presentation/mapper/PointControllerMapper.java
+++ b/benefit-service/src/main/java/com/waitless/benefit/point/presentation/mapper/PointControllerMapper.java
@@ -5,7 +5,9 @@ import com.waitless.benefit.point.application.dto.command.GetPointAmountCommand;
 import com.waitless.benefit.point.application.dto.command.SearchRankingCommand;
 import com.waitless.benefit.point.domain.vo.PointSearchCondition;
 import com.waitless.benefit.point.presentation.dto.request.*;
+import com.waitless.common.domain.UserInfoDto;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface PointControllerMapper {
@@ -16,7 +18,11 @@ public interface PointControllerMapper {
     default PointSearchCondition toCondition(GetPointListRequestDto requestDto) {
         return new PointSearchCondition(null, requestDto.userId());
     }
-    GetPointAmountCommand toCommand(GetPointAmountRequestDto requestDto);
-    SearchRankingCommand toCommand(SearchRankingRequestDto requestDto);
-    GetMyRankingCommand toCommand(GetMyRankingRequestDto requestDto);
+    @Mapping(source = "userInfoDto.userId", target = "userId")
+    @Mapping(source = "userInfoDto", target = "userInfoDto")
+    GetPointAmountCommand toCommand(GetPointAmountRequestDto requestDto, UserInfoDto userInfoDto);
+    SearchRankingCommand toCommand(SearchRankingRequestDto requestDto, UserInfoDto userInfoDto);
+    @Mapping(source = "userInfoDto.userId", target = "userId")
+    @Mapping(source = "userInfoDto", target = "userInfoDto")
+    GetMyRankingCommand toCommand(GetMyRankingRequestDto requestDto, UserInfoDto userInfoDto);
 }

--- a/common/src/main/java/com/waitless/common/config/FeignClientConfig.java
+++ b/common/src/main/java/com/waitless/common/config/FeignClientConfig.java
@@ -1,0 +1,26 @@
+package com.waitless.common.config;
+
+import feign.RequestInterceptor;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Configuration
+public class FeignClientConfig {
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return requestTemplate -> {
+            ServletRequestAttributes attrs = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+            if (attrs != null) {
+                HttpServletRequest request = attrs.getRequest();
+                String userId = request.getHeader("X-User-Id");
+                String role = request.getHeader("X-User-Role");
+
+                if (userId != null) requestTemplate.header("X-User-Id", userId);
+                if (role != null) requestTemplate.header("X-User-Role", role);
+            }
+        };
+    }
+}

--- a/common/src/main/java/com/waitless/common/config/WebConfig.java
+++ b/common/src/main/java/com/waitless/common/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.waitless.common.config;
+
+import java.util.List;
+
+import com.waitless.common.global.UserInfoArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    private final UserInfoArgumentResolver userInfoArgumentResolver;
+    public WebConfig(UserInfoArgumentResolver userInfoArgumentResolver) {
+        this.userInfoArgumentResolver = userInfoArgumentResolver;
+    }
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(userInfoArgumentResolver);
+    }
+}

--- a/common/src/main/java/com/waitless/common/domain/AuditorAwareImpl.java
+++ b/common/src/main/java/com/waitless/common/domain/AuditorAwareImpl.java
@@ -1,0 +1,31 @@
+package com.waitless.common.domain;
+
+import java.util.Optional;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Component
+public class AuditorAwareImpl implements AuditorAware<Long> {
+    private static final String USER_ID_HEADER = "X-User-Id";
+    @Override
+    public Optional<Long> getCurrentAuditor() {
+
+        return Optional.ofNullable(RequestContextHolder.getRequestAttributes())
+                .filter(ServletRequestAttributes.class::isInstance)
+                .map(ServletRequestAttributes.class::cast)
+                .map(ServletRequestAttributes::getRequest)
+                .map(request -> request.getHeader(USER_ID_HEADER))
+                .filter(userId -> !userId.isEmpty())
+                .flatMap(this::parseUserId);
+    }
+    private Optional<Long> parseUserId(String userId) {
+        try {
+            return Optional.of(Long.parseLong(userId));
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+    }
+}
+

--- a/common/src/main/java/com/waitless/common/domain/UserInfo.java
+++ b/common/src/main/java/com/waitless/common/domain/UserInfo.java
@@ -1,0 +1,11 @@
+package com.waitless.common.domain;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserInfo {
+}

--- a/common/src/main/java/com/waitless/common/domain/UserInfoDto.java
+++ b/common/src/main/java/com/waitless/common/domain/UserInfoDto.java
@@ -1,0 +1,21 @@
+package com.waitless.common.domain;
+
+public record UserInfoDto(Long userId, Role role) {
+    public static UserInfoDto of(String userId, String role) {
+        if(userId == null || role == null) {
+            return empty();
+        }
+        return parseUserInfo(userId, role);
+    }
+    public static UserInfoDto empty() {
+        return new UserInfoDto(null, null);
+    }
+
+    private static UserInfoDto parseUserInfo(String userId, String role) {
+        try {
+            return new UserInfoDto(Long.parseLong(userId),Role.valueOf(role));
+        } catch (IllegalArgumentException e) {
+            return empty();
+        }
+    }
+}

--- a/common/src/main/java/com/waitless/common/global/UserInfoArgumentResolver.java
+++ b/common/src/main/java/com/waitless/common/global/UserInfoArgumentResolver.java
@@ -1,0 +1,45 @@
+package com.waitless.common.global;
+
+import com.waitless.common.domain.UserInfo;
+import com.waitless.common.domain.UserInfoDto;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class UserInfoArgumentResolver implements HandlerMethodArgumentResolver {
+    private static final String USER_ID_HEADER = "X-User-Id";
+    private static final String USER_ROLE_HEADER = "X-User-Role";
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+
+        return parameter.hasParameterAnnotation(UserInfo.class)
+                && parameter.getParameterType().equals(UserInfoDto.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+
+        return Optional.of(webRequest.getNativeRequest())
+                .filter(HttpServletRequest.class::isInstance)
+                .map(HttpServletRequest.class::cast)
+                .map(this::extractUserInfo)
+                .orElse(UserInfoDto.empty());
+    }
+
+    private UserInfoDto extractUserInfo(HttpServletRequest request) {
+
+        return UserInfoDto.of(
+                request.getHeader(USER_ID_HEADER),
+                request.getHeader(USER_ROLE_HEADER));
+    }
+}

--- a/review-service/src/main/java/com/waitless/review/application/dto/command/DeleteReviewCommand.java
+++ b/review-service/src/main/java/com/waitless/review/application/dto/command/DeleteReviewCommand.java
@@ -1,8 +1,11 @@
 package com.waitless.review.application.dto.command;
 
+import com.waitless.common.domain.UserInfoDto;
+
 import java.util.UUID;
 
 public record DeleteReviewCommand(
         UUID reviewId,
-        Long userId
+        Long userId,
+        UserInfoDto userInfoDto
 ) {}

--- a/review-service/src/main/java/com/waitless/review/application/dto/command/PostReviewCommand.java
+++ b/review-service/src/main/java/com/waitless/review/application/dto/command/PostReviewCommand.java
@@ -1,5 +1,7 @@
 package com.waitless.review.application.dto.command;
 
+import com.waitless.common.domain.UserInfoDto;
+
 import java.util.UUID;
 
 public record PostReviewCommand(
@@ -7,5 +9,6 @@ public record PostReviewCommand(
         Long userId,
         UUID restaurantId,
         String content,
-        Integer rating
+        Integer rating,
+        UserInfoDto userInfoDto
 ) {}

--- a/review-service/src/main/java/com/waitless/review/application/dto/command/ReviewStatisticsCommand.java
+++ b/review-service/src/main/java/com/waitless/review/application/dto/command/ReviewStatisticsCommand.java
@@ -1,8 +1,11 @@
 package com.waitless.review.application.dto.command;
 
+import com.waitless.common.domain.UserInfoDto;
+
 import java.util.List;
 import java.util.UUID;
 
 public record ReviewStatisticsCommand(
-        List<UUID> restaurantIds
+        List<UUID> restaurantIds,
+        UserInfoDto userInfoDto
 ) {}

--- a/review-service/src/main/java/com/waitless/review/application/service/ReviewService.java
+++ b/review-service/src/main/java/com/waitless/review/application/service/ReviewService.java
@@ -18,5 +18,5 @@ public interface ReviewService {
     GetReviewResult findOne(ReviewSearchCondition condition); // 단건 조회
     PageCommand<GetReviewListResult> findList(ReviewSearchCondition condition, Pageable pageable); // 리스트 조회
     PageCommand<SearchReviewsResult> findSearch(ReviewSearchCondition condition, Pageable pageable); // 조건 조회
-    Map<UUID, ReviewStatisticsResult> getStatisticsBatch(ReviewStatisticsCommand command);
+    Map<UUID, ReviewStatisticsResult> getStatisticsBatch(ReviewStatisticsCommand command); // 배치형 통계 조회
 }

--- a/review-service/src/main/java/com/waitless/review/application/service/ReviewServiceImpl.java
+++ b/review-service/src/main/java/com/waitless/review/application/service/ReviewServiceImpl.java
@@ -44,7 +44,7 @@ public class ReviewServiceImpl implements ReviewService, ReviewCommandUseCase {
     @Override
     @Transactional
     public PostReviewResult createReview(PostReviewCommand command) {
-//        visitedReservationValidator.validate(command);
+        visitedReservationValidator.validate(command);
         Review review = reviewServiceMapper.toEntity(command);
         Review saved = reviewRepository.save(review);
 
@@ -65,7 +65,7 @@ public class ReviewServiceImpl implements ReviewService, ReviewCommandUseCase {
     public DeleteReviewResult deleteReview(DeleteReviewCommand command) {
         Review review = reviewRepository.findById(command.reviewId())
                 .orElseThrow(() -> new IllegalArgumentException("리뷰가 존재하지 않습니다."));
-        if (!review.getUserId().equals(command.userId())) {
+        if (!review.getUserId().equals(command.userInfoDto().userId())) {
             throw new IllegalArgumentException("작성자만 삭제할 수 있습니다.");
         }
         review.softDelete();

--- a/review-service/src/main/java/com/waitless/review/application/validator/VisitedReservationValidatorImpl.java
+++ b/review-service/src/main/java/com/waitless/review/application/validator/VisitedReservationValidatorImpl.java
@@ -24,7 +24,7 @@ public class VisitedReservationValidatorImpl implements VisitedReservationValida
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("방문 완료된 예약이 아닙니다."));
 
-        if (!dto.userId().equals(command.userId()) || !dto.restaurantId().equals(command.restaurantId())) {
+        if (!dto.userId().equals(command.userInfoDto().userId()) || !dto.restaurantId().equals(command.restaurantId())) {
             throw new IllegalArgumentException("예약 정보와 사용자 정보가 일치하지 않습니다.");
         }
     }

--- a/review-service/src/main/java/com/waitless/review/infrastructure/adaptor/out/client/ReservationInternalClient.java
+++ b/review-service/src/main/java/com/waitless/review/infrastructure/adaptor/out/client/ReservationInternalClient.java
@@ -1,5 +1,6 @@
 package com.waitless.review.infrastructure.adaptor.out.client;
 
+import com.waitless.common.config.FeignClientConfig;
 import com.waitless.review.infrastructure.adaptor.out.client.dto.ReservationServiceRequest;
 import com.waitless.review.infrastructure.adaptor.out.client.dto.ReservationServiceResponse;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -10,7 +11,8 @@ import java.util.List;
 
 @FeignClient(
         name = "reservation-service",
-        url = "http://localhost:19094"
+        url = "http://localhost:19094",
+        configuration = FeignClientConfig.class
 )
 public interface ReservationInternalClient {
     @PostMapping("/api/v1/app/reservations/visited")

--- a/review-service/src/main/java/com/waitless/review/presentation/controller/ReviewExternalController.java
+++ b/review-service/src/main/java/com/waitless/review/presentation/controller/ReviewExternalController.java
@@ -1,5 +1,9 @@
 package com.waitless.review.presentation.controller;
 
+import com.waitless.common.aop.RoleCheck;
+import com.waitless.common.domain.Role;
+import com.waitless.common.domain.UserInfo;
+import com.waitless.common.domain.UserInfoDto;
 import com.waitless.common.exception.response.SingleResponse;
 import com.waitless.review.application.dto.command.DeleteReviewCommand;
 import com.waitless.review.application.dto.command.PostReviewCommand;
@@ -24,27 +28,33 @@ public class ReviewExternalController {
     private final ReviewService reviewService;
     private final ReviewControllerMapper reviewControllerMapper;
 
+    @RoleCheck(roles = {Role.USER, Role.ADMIN})
     @PostMapping
     public ResponseEntity<SingleResponse<PostReviewResponseDto>> createReview(
-            @Valid @RequestBody PostReviewRequestDto requestDto) {
-        PostReviewCommand command = reviewControllerMapper.toCommand(requestDto);
+            @Valid @RequestBody PostReviewRequestDto requestDto,
+            @UserInfo UserInfoDto userInfoDto
+    ) {
+        PostReviewCommand command = reviewControllerMapper.toCommand(requestDto, userInfoDto);
         PostReviewResponseDto responseDto = PostReviewResponseDto.from(
                 reviewService.createReview(command)
         );
         return ResponseEntity.ok(SingleResponse.success(responseDto));
     }
 
+    @RoleCheck(roles = {Role.USER, Role.ADMIN})
     @DeleteMapping
     public ResponseEntity<SingleResponse<DeleteReviewResponseDto>> deleteReview(
-            @RequestBody DeleteReviewRequestDto requestDto
+            @RequestBody DeleteReviewRequestDto requestDto,
+            @UserInfo UserInfoDto userInfoDto
     ) {
-        DeleteReviewCommand command = reviewControllerMapper.toCommand(requestDto);
+        DeleteReviewCommand command = reviewControllerMapper.toCommand(requestDto, userInfoDto);
         DeleteReviewResponseDto responseDto = DeleteReviewResponseDto.from(
                 reviewService.deleteReview(command)
         );
         return ResponseEntity.ok(SingleResponse.success(responseDto));
     }
 
+    @RoleCheck(roles = {Role.USER, Role.ADMIN, Role.OWNER})
     @GetMapping("/{reviewId}")
     public ResponseEntity<SingleResponse<GetReviewResponseDto>> getReview(
             @PathVariable("reviewId") UUID reviewId
@@ -57,6 +67,7 @@ public class ReviewExternalController {
         return ResponseEntity.ok(SingleResponse.success(responseDto));
     }
 
+    @RoleCheck(roles = {Role.USER, Role.ADMIN, Role.OWNER})
     @GetMapping("/list")
     public ResponseEntity<SingleResponse<GetReviewListResponseDto>> getReviewList(
             @ModelAttribute GetReviewListRequestDto requestDto,
@@ -69,6 +80,7 @@ public class ReviewExternalController {
         return ResponseEntity.ok(SingleResponse.success(responseDto));
     }
 
+    @RoleCheck(roles = {Role.USER, Role.ADMIN, Role.OWNER})
     @GetMapping("/search")
     public ResponseEntity<SingleResponse<SearchReviewsResponseDto>> searchReviews(
             @ModelAttribute SearchReviewsRequestDto requestDto,

--- a/review-service/src/main/java/com/waitless/review/presentation/controller/ReviewInternalController.java
+++ b/review-service/src/main/java/com/waitless/review/presentation/controller/ReviewInternalController.java
@@ -1,6 +1,9 @@
 package com.waitless.review.presentation.controller;
 
-import com.waitless.common.exception.response.SingleResponse;
+import com.waitless.common.aop.RoleCheck;
+import com.waitless.common.domain.Role;
+import com.waitless.common.domain.UserInfo;
+import com.waitless.common.domain.UserInfoDto;
 import com.waitless.review.application.dto.command.ReviewStatisticsCommand;
 import com.waitless.review.application.dto.result.ReviewStatisticsResult;
 import com.waitless.review.application.service.ReviewService;
@@ -8,8 +11,10 @@ import com.waitless.review.presentation.dto.request.ReviewStatisticsBatchRequest
 import com.waitless.review.presentation.dto.response.ReviewStatisticsBatchResponseDto;
 import com.waitless.review.presentation.mapper.ReviewControllerMapper;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.Map;
@@ -22,11 +27,14 @@ public class ReviewInternalController {
 
     private final ReviewService reviewService;
     private final ReviewControllerMapper reviewControllerMapper;
+
+    @RoleCheck(roles = {Role.OWNER, Role.ADMIN})
     @PostMapping
     public List<ReviewStatisticsBatchResponseDto> getStatisticsBatch(
-            @RequestBody ReviewStatisticsBatchRequestDto requestDto
+            @RequestBody ReviewStatisticsBatchRequestDto requestDto,
+            @UserInfo UserInfoDto userInfoDto
     ) {
-        ReviewStatisticsCommand command = reviewControllerMapper.toCommand(requestDto);
+        ReviewStatisticsCommand command = reviewControllerMapper.toCommand(requestDto, userInfoDto);
         Map<UUID, ReviewStatisticsResult> resultMap = reviewService.getStatisticsBatch(command);
         return ReviewStatisticsBatchResponseDto.fromMap(resultMap);
     }

--- a/review-service/src/main/java/com/waitless/review/presentation/mapper/ReviewControllerMapper.java
+++ b/review-service/src/main/java/com/waitless/review/presentation/mapper/ReviewControllerMapper.java
@@ -1,16 +1,29 @@
 package com.waitless.review.presentation.mapper;
 
+import com.waitless.common.domain.UserInfoDto;
 import com.waitless.review.application.dto.command.DeleteReviewCommand;
 import com.waitless.review.application.dto.command.PostReviewCommand;
 import com.waitless.review.application.dto.command.ReviewStatisticsCommand;
 import com.waitless.review.domain.vo.ReviewSearchCondition;
 import com.waitless.review.presentation.dto.request.*;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface ReviewControllerMapper {
-    PostReviewCommand toCommand(PostReviewRequestDto requestDto);
-    DeleteReviewCommand toCommand(DeleteReviewRequestDto requestDto);
+
+    @Mapping(source = "requestDto.reservationId", target = "reservationId")
+    @Mapping(source = "requestDto.restaurantId", target = "restaurantId")
+    @Mapping(source = "requestDto.content", target = "content")
+    @Mapping(source = "requestDto.rating", target = "rating")
+    @Mapping(source = "userInfoDto.userId", target = "userId")
+    @Mapping(source = "userInfoDto", target = "userInfoDto")
+    PostReviewCommand toCommand(PostReviewRequestDto requestDto, UserInfoDto userInfoDto);
+
+    @Mapping(source = "requestDto.reviewId", target = "reviewId")
+    @Mapping(source = "userInfoDto.userId", target = "userId")
+    @Mapping(source = "userInfoDto", target = "userInfoDto")
+    DeleteReviewCommand toCommand(DeleteReviewRequestDto requestDto, UserInfoDto userInfoDto);
     default ReviewSearchCondition toCondition(GetReviewRequestDto requestDto) {
         return new ReviewSearchCondition(requestDto.reviewId(), null, null, null);
     }
@@ -20,7 +33,5 @@ public interface ReviewControllerMapper {
     default ReviewSearchCondition toCondition(SearchReviewsRequestDto requestDto) {
         return new ReviewSearchCondition(null, requestDto.userId(), requestDto.restaurantId(), requestDto.rating());
     }
-    default ReviewStatisticsCommand toCommand(ReviewStatisticsBatchRequestDto requestDto) {
-        return new ReviewStatisticsCommand(requestDto.restaurantIds());
-    }
+    ReviewStatisticsCommand toCommand(ReviewStatisticsBatchRequestDto requestDto, UserInfoDto userInfoDto);
 }


### PR DESCRIPTION
## 🔍 작업 내용
>내부 FeignClients 호출에도 권한검증 추가, 리뷰 서비스/포인트 권한검증+롤체킹 추가

## 📝작업 내용

> 공통모듈에 권한검증 Config,Resolver,Auditor,UserInfoDto 추가/리뷰,포인트 Controller,Mapper,Command에 UserInfoDto 추가 및 검증 로직을 command.userInfo.userId()로 변경.

## ✅ 체크리스트
> 혹시 빠뜨린 건 없는지! 체크리스트 한 번만 더 확인해볼까요? 👀
- [x] 코드 컨벤션을 준수했나요?
- [x] 브랜치를 최신화 했나요?
- [x] 테스트를 완료 했나요?

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


## 🔗 관련 이슈
> pr에 관련된 issue num 을 작성해 주세요.

Closes #176 