### PR TITLE
Feat/reservation 179 visit request send

### DIFF
--- a/common/src/main/java/com/waitless/common/event/VisitRequestMessageEvent.java
+++ b/common/src/main/java/com/waitless/common/event/VisitRequestMessageEvent.java
@@ -1,0 +1,4 @@
+package com.waitless.common.event;
+
+public record VisitRequestMessageEvent (String slackId, String message){
+}

--- a/reservation-service/src/main/java/com/waitless/reservation/application/event/KafkaSlackEventProducer.java
+++ b/reservation-service/src/main/java/com/waitless/reservation/application/event/KafkaSlackEventProducer.java
@@ -1,6 +1,7 @@
 package com.waitless.reservation.application.event;
 
 import com.waitless.common.dto.ReservationCancelEvent;
+import com.waitless.common.event.VisitRequestMessageEvent;
 import com.waitless.reservation.application.event.dto.ReviewRequestEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -13,6 +14,7 @@ public class KafkaSlackEventProducer {
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private static final String REVIEW_TOPIC = "review-request";
     private static final String CANCEL_TOPIC = "cancel-request";
+    private static final String VISIT_TOPIC = "visit-request";
 
 
     public void sendReviewRequest(ReviewRequestEvent event) {
@@ -21,5 +23,9 @@ public class KafkaSlackEventProducer {
 
     public void sendCancelRequest(ReservationCancelEvent event) {
         kafkaTemplate.send(CANCEL_TOPIC, event);
+    }
+
+    public void sendVisitRequest(VisitRequestMessageEvent event) {
+        kafkaTemplate.send(VISIT_TOPIC, event);
     }
 }

--- a/reservation-service/src/main/java/com/waitless/reservation/application/event/RedisShutdownListener.java
+++ b/reservation-service/src/main/java/com/waitless/reservation/application/event/RedisShutdownListener.java
@@ -1,23 +1,28 @@
 package com.waitless.reservation.application.event;
 
-import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
+
+import java.util.Set;
 
 /**
  * 테스트를 위해 웹 종료하면 redis 데이터 삭제
  */
 @Component
 @RequiredArgsConstructor
-public class RedisShutdownListener {
+public class RedisShutdownListener implements ApplicationListener<ContextClosedEvent> {
 
     private final StringRedisTemplate redisTemplate;
 
-    @PreDestroy
-    public void cleanUp() {
-        redisTemplate.delete(redisTemplate.keys("reservation:*"));
-        redisTemplate.delete(redisTemplate.keys("stock:*"));
-        System.out.println("Redis 정리 완료 (@PreDestroy)");
+    @Override
+    public void onApplicationEvent(ContextClosedEvent event) {
+        Set<String> reservationKeys = redisTemplate.keys("reservation:*");
+        redisTemplate.delete(reservationKeys);
+        Set<String> stockKeys = redisTemplate.keys("stock:*");
+        redisTemplate.delete(stockKeys);
+        System.out.println("Redis 정리 완료 (ContextClosedEvent)");
     }
 }

--- a/reservation-service/src/main/java/com/waitless/reservation/application/event/ReservationMessageEventHandler.java
+++ b/reservation-service/src/main/java/com/waitless/reservation/application/event/ReservationMessageEventHandler.java
@@ -1,22 +1,29 @@
 package com.waitless.reservation.application.event;
 
 import com.waitless.common.dto.ReservationCancelEvent;
+import com.waitless.common.event.VisitRequestMessageEvent;
 import com.waitless.common.exception.BusinessException;
 import com.waitless.common.exception.response.SingleResponse;
 import com.waitless.reservation.application.event.dto.*;
 import com.waitless.reservation.application.service.message.MessageService;
+import com.waitless.reservation.domain.entity.Reservation;
+import com.waitless.reservation.domain.repository.ReservationRepository;
 import com.waitless.reservation.exception.exception.ReservationErrorCode;
 import com.waitless.reservation.infrastructure.adaptor.client.UserClient;
 import com.waitless.reservation.infrastructure.adaptor.client.dto.UserResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.util.Optional;
+import java.util.UUID;
 
 @RequiredArgsConstructor
 @Component
@@ -27,6 +34,11 @@ public class ReservationMessageEventHandler {
     private final MessageService messageService;
     private final KafkaSlackEventProducer kafkaSlackEventProducer;
     private final KafkaCompletedReservationEventProducer kafkaCompletedReservationEventProducer;
+    private final StringRedisTemplate redisTemplate;
+    private final ReservationRepository reservationRepository;
+
+    private static final String QUEUE_PREFIX = "reservation:queue:";
+
 
     @Async("messageExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -38,7 +50,8 @@ public class ReservationMessageEventHandler {
             String message = messageService.buildVisitCompleteMessage(slackId, event.restaurantName(), event.userId());
             kafkaSlackEventProducer.sendReviewRequest(new ReviewRequestEvent(slackId, message));
         } catch (Exception e) {
-            log.error("슬랙 메시지 전송 실패 :: 예약ID = {}, userId = {}", event.reservationId(), event.userId(), e);        }
+            log.error("슬랙 메시지 전송 실패 :: 예약ID = {}, userId = {}", event.reservationId(), event.userId(), e);
+        }
     }
 
     @Async("messageExecutor")
@@ -46,9 +59,10 @@ public class ReservationMessageEventHandler {
     public void handleCompletedReservation(ReservationCompleteEvent event) {
         try {
             String slackId = getSlackId(event.userId());
-            kafkaCompletedReservationEventProducer.sendCompletedReservation(new CompletedReservationEvent(slackId,event.sequence().intValue()));
+            kafkaCompletedReservationEventProducer.sendCompletedReservation(new CompletedReservationEvent(slackId, event.sequence().intValue()));
         } catch (Exception e) {
-            log.error("예약 완료 슬랙 메시지 전송 실패 :: 순번 = {}, userId = {}", event.sequence(), event.userId(), e);        }
+            log.error("예약 완료 슬랙 메시지 전송 실패 :: 순번 = {}, userId = {}", event.sequence(), event.userId(), e);
+        }
     }
 
     @Async("messageExecutor")
@@ -60,6 +74,51 @@ public class ReservationMessageEventHandler {
             kafkaSlackEventProducer.sendCancelRequest(new ReservationCancelEvent(slackId, message));
         } catch (Exception e) {
             log.error("취소 슬랙 메시지 전송 실패 :: userid = {}", event.userId(), e);
+        }
+    }
+
+    @Async("messageExecutor")
+    @EventListener
+    @Transactional(readOnly = true)
+    public void handleVisitRequestReservation(VisitRequestEvent event) {
+        UUID restaurantId = event.restaurantId();
+        String zsetKey = QUEUE_PREFIX + restaurantId;
+        String alertKey = "reservation:alerted:" + restaurantId;
+
+        try {
+            String topReservationId = redisTemplate.opsForZSet()
+                    .range(zsetKey, 0, 0)
+                    .stream()
+                    .findFirst()
+                    .orElse(null);
+
+            if (topReservationId == null) {
+                log.info("[Queue] 식당 {}: 대기열 비어있음", restaurantId);
+                return;
+            }
+
+            // 이미 알림 보낸 예약인지 확인
+            String lastAlertedId = redisTemplate.opsForValue().get(alertKey);
+            if (topReservationId.equals(lastAlertedId)) {
+                log.info("[Queue] 식당 {}: 예약 {}는 이미 알림 전송됨", restaurantId, topReservationId);
+                return;
+            }
+
+            // 예약 조회
+            Reservation reservation = reservationRepository.findById(UUID.fromString(topReservationId))
+                    .orElseThrow(() -> BusinessException.from(ReservationErrorCode.RESERVATION_NOT_FOUND));
+
+            // 사용자 Slack ID 조회 및 메시지 발송
+//            String slackId = getSlackId(reservation.getUserId());
+            String slackId = "asdasd";
+            String message = messageService.buildVisitRequestMessage(reservation.getRestaurantName());
+            kafkaSlackEventProducer.sendVisitRequest(new VisitRequestMessageEvent(slackId, message));
+
+            // 알림 보낸 예약 ID 기록
+            redisTemplate.opsForValue().set(alertKey, topReservationId);
+            log.info("[Queue] 식당 {}: 예약 {}에게 입장 요청 메시지 전송 완료", restaurantId, topReservationId);
+        } catch (Exception e) {
+            log.error("[Queue] 식당 {}: 1등 메시지 전송 실패", restaurantId, e);
         }
     }
 

--- a/reservation-service/src/main/java/com/waitless/reservation/application/event/dto/ReservationSaveEvent.java
+++ b/reservation-service/src/main/java/com/waitless/reservation/application/event/dto/ReservationSaveEvent.java
@@ -1,0 +1,9 @@
+package com.waitless.reservation.application.event.dto;
+
+import com.waitless.common.dto.StockDto;
+import com.waitless.reservation.domain.entity.Reservation;
+
+import java.util.List;
+
+public record ReservationSaveEvent(Reservation reservation, List<StockDto> stockDtos, Long reservationNumber) {
+}

--- a/reservation-service/src/main/java/com/waitless/reservation/application/event/dto/VisitRequestEvent.java
+++ b/reservation-service/src/main/java/com/waitless/reservation/application/event/dto/VisitRequestEvent.java
@@ -1,0 +1,6 @@
+package com.waitless.reservation.application.event.dto;
+
+import java.util.UUID;
+
+public record VisitRequestEvent(UUID restaurantId) {
+}

--- a/reservation-service/src/main/java/com/waitless/reservation/application/service/command/ReservationCommandServiceImpl.java
+++ b/reservation-service/src/main/java/com/waitless/reservation/application/service/command/ReservationCommandServiceImpl.java
@@ -6,10 +6,9 @@ import com.waitless.common.exception.BusinessException;
 import com.waitless.reservation.application.dto.CancelMenuDto;
 import com.waitless.reservation.application.dto.ReservationCreateCommand;
 import com.waitless.reservation.application.dto.ReservationCreateResponse;
-import com.waitless.reservation.application.event.KafkaSlackEventProducer;
+import com.waitless.reservation.application.event.dto.ReservationCancelRequestEvent;
 import com.waitless.reservation.application.event.dto.ReservationCompleteEvent;
 import com.waitless.reservation.application.event.dto.ReservationVisitedEvent;
-import com.waitless.reservation.application.event.dto.ReservationCancelRequestEvent;
 import com.waitless.reservation.application.interceptor.UserContext;
 import com.waitless.reservation.application.mapper.ReservationServiceMapper;
 import com.waitless.reservation.application.service.redis.RedisReservationQueueService;
@@ -20,7 +19,6 @@ import com.waitless.reservation.domain.entity.ReservationStatus;
 import com.waitless.reservation.domain.repository.ReservationRepository;
 import com.waitless.reservation.exception.exception.ReservationErrorCode;
 import com.waitless.reservation.infrastructure.adaptor.client.RestaurantClient;
-import com.waitless.reservation.infrastructure.adaptor.client.dto.RestaurantResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -74,8 +72,6 @@ public class ReservationCommandServiceImpl implements ReservationCommandService 
                 .toList();
 
         eventPublisher.publishEvent(new StockDecreasedEvent(reservation.getId(), stockDtos));
-        log.debug("예약 생성 :: Redis 재고 차감 및 DB 저장 완료: {}", storeId);
-
         return reservationServiceMapper.toReservationCreateResponse(reservation);
     }
 

--- a/reservation-service/src/main/java/com/waitless/reservation/application/service/message/MessageService.java
+++ b/reservation-service/src/main/java/com/waitless/reservation/application/service/message/MessageService.java
@@ -4,4 +4,6 @@ public interface MessageService {
     String buildVisitCompleteMessage(String slackId, String restaurantName, Long userId);
 
     String buildCancelMessage(String restaurantName);
+
+    String buildVisitRequestMessage(String restaurantName);
 }

--- a/reservation-service/src/main/java/com/waitless/reservation/application/service/message/SlackMessageService.java
+++ b/reservation-service/src/main/java/com/waitless/reservation/application/service/message/SlackMessageService.java
@@ -13,6 +13,9 @@ public class SlackMessageService implements MessageService {
     private static final String CANCEL_MESSAGE_TEMPLATE =
             "%s 예약이 취소되었습니다.\n취소하신 적이 없으면 고객센터로 연락주세요.";
 
+    private static final String VISIT_REQUEST_MESSAGE_TEMPLATE =
+            "%s 식당의 입장할 순번이 1번쨰가 되었습니다.\n 식당 앞에서 기다려 주세요.";
+
 
     @Override
     public String buildVisitCompleteMessage(String slackId, String restaurantName, Long userId) {
@@ -23,5 +26,10 @@ public class SlackMessageService implements MessageService {
     @Override
     public String buildCancelMessage(String restaurantName) {
         return String.format(CANCEL_MESSAGE_TEMPLATE, restaurantName);
+    }
+
+    @Override
+    public String buildVisitRequestMessage(String restaurantName) {
+        return String.format(VISIT_REQUEST_MESSAGE_TEMPLATE, restaurantName);
     }
 }

--- a/reservation-service/src/main/java/com/waitless/reservation/application/service/redis/RedisReservationQueueService.java
+++ b/reservation-service/src/main/java/com/waitless/reservation/application/service/redis/RedisReservationQueueService.java
@@ -31,6 +31,7 @@ public class RedisReservationQueueService {
     public void removeFromWaitingQueue(UUID reservationId, LocalDate reservationDate, UUID restaurantId) {
         String zsetKey = QUEUE_PREFIX + restaurantId;
         redisTemplate.opsForZSet().remove(zsetKey, String.valueOf(reservationId));
+        message(restaurantId);
     }
 
     public Long findCurrentNumberFromWaitingQueue(UUID reservationId, UUID restaurantId) {
@@ -62,6 +63,37 @@ public class RedisReservationQueueService {
         } catch (Exception e) {
             log.error("순번 미루기 LuaScript 오류", e);
             throw BusinessException.from(CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private void message(UUID restaurantId) {
+        String zsetKey = QUEUE_PREFIX + restaurantId;
+        String alertKey = "reservation:alerted:" + restaurantId;
+
+        // 현재 대기열 1번 사용자 가져오기
+        var top1 = redisTemplate.opsForZSet().range(zsetKey, 0, 0);
+        if (top1 == null || top1.isEmpty()) {
+            log.info("[Queue] 식당 {}: 대기열 비어있음", restaurantId);
+            return;
+        }
+
+        String currentTopReservationId = top1.iterator().next();
+
+        redisTemplate.opsForValue().set(alertKey, currentTopReservationId);
+
+        String lastReservationId = redisTemplate.opsForValue().get(alertKey);
+
+        if (currentTopReservationId.equals(lastReservationId)) {
+            log.info("[Queue] 식당 {}: 사용자 {}는 이미 알림 보냄", restaurantId, currentTopReservationId);
+            return;
+        }
+
+        try {
+
+            redisTemplate.opsForValue().set(alertKey, currentTopReservationId);
+            log.info("[Queue] 식당 {}: 예약ID {}에게 입장 메시지 전송 완료", restaurantId, currentTopReservationId);
+        } catch (Exception e) {
+            log.error("[Queue] 식당 {}: 예약ID {}에게 메시지 전송 실패", restaurantId, currentTopReservationId, e);
         }
     }
 }

--- a/reservation-service/src/main/java/com/waitless/reservation/infrastructure/config/async/AsyncConfig.java
+++ b/reservation-service/src/main/java/com/waitless/reservation/infrastructure/config/async/AsyncConfig.java
@@ -6,6 +6,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
 
 @Configuration
 @EnableAsync
@@ -14,9 +15,10 @@ public class AsyncConfig {
     @Bean(name = "messageExecutor")
     public Executor asyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(4); // 기본 쓰레드 수
-        executor.setMaxPoolSize(10); // 최대 쓰레드 수
-        executor.setQueueCapacity(100); // 큐 수용량
+        executor.setCorePoolSize(16);
+        executor.setMaxPoolSize(100);
+        executor.setQueueCapacity(1000);
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy()); // 최소한 메인 스레드로라도 처리
         executor.setThreadNamePrefix("messageExecutor-");
         executor.initialize();
         return executor;


### PR DESCRIPTION
## 🔍 작업 내용
대기순번 1번 메시지 발행

## 📝작업 내용
식당 방문, 예약 취소 요청 들어오면 그 예약을 대기순번 큐에서 제거한다.
제거함과 동시에 그 식당의 대기순번 1번인 사용자에게 식당 앞에서 대기해달라고 비동기로 메시지 보냄.
중복 메시지 요청을 막기 위해 가장 최근에 메시지 보낸 사람을 Redis에 저장하고 비교해서 요청.


## ✅ 체크리스트
> 혹시 빠뜨린 건 없는지! 체크리스트 한 번만 더 확인해볼까요? 👀
- [x] 코드 컨벤션을 준수했나요?
- [x] 브랜치를 최신화 했나요?
- [x] 테스트를 완료 했나요?

## 💬리뷰 요구사항(선택)


## 🔗 관련 이슈
Closes #179 